### PR TITLE
Fix Typescript validation issues with --strictNullCheck

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,7 @@ class WebpackObfuscator {
     public apply (compiler: Compiler): void {
         compiler.plugin('compilation', (compilation: any) => {
             compilation.plugin("optimize-chunk-assets", (chunks: any[], callback: () => void) => {
-                let files = [];
+                let files: any[] = [];
 
                 chunks.forEach((chunk) => {
                     chunk['files'].forEach((file) => {


### PR DESCRIPTION
You will find below an example of errors this change addresses:
```
 ERROR in [at-loader] ./node_modules/webpack-obfuscator/index.ts:48:32
        TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
```