### PR TITLE
fix: typescript exports default

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -124,4 +124,4 @@ class WebpackObfuscator {
     }
 }
 
-module.exports = WebpackObfuscator;
+export default WebpackObfuscator;


### PR DESCRIPTION
Otherwise I get a TS1192 error, even when using the `esModuleInterop` setting.