### PR TITLE
fix: typescript constructor optional arguments

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,7 +25,7 @@ class WebpackObfuscator {
      * @param {TObject} options
      * @param {string | string[]} excludes
      */
-    constructor (options: TObject, excludes: string|string[]) {
+    constructor (options?: TObject, excludes?: string|string[]) {
         this.options = options || {};
         this.excludes = this.prepareExcludes(excludes);
     }


### PR DESCRIPTION
Since the constructor arguments have defaults and are optional, the TypeScript should indicate as much.