### PR TITLE
Fix source maps generation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -42,7 +42,7 @@ class WebpackObfuscator {
                     if (this.options.sourceMap && inputSourceMap) {
                         const transferredSourceMap = transferSourceMap({
                             fromSourceMap: obfuscationSourceMap,
-                            toSourceMap: inputSource
+                            toSourceMap: inputSourceMap
                         });
 
                         compilation.assets[fileName] = new SourceMapSource(


### PR DESCRIPTION
Enabling the `sourceMap` option always crashed the plugin for me. So I went through the code and noticed that `inputSourceMap` should be passed to the `transfer` function from `multi-stage-sourcemap` instead of `inputSource`