### PR TITLE
Remove unused webpack-sources dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,10 @@
             "dependencies": {
                 "loader-utils": "^2.0.0",
                 "multi-stage-sourcemap": "^0.3.1",
-                "multimatch": "^5.0.0",
-                "webpack-sources": "^2.0.1"
+                "multimatch": "^5.0.0"
             },
             "devDependencies": {
                 "@types/node": "^14.11.8",
-                "@types/webpack-sources": "^2.0.0",
                 "javascript-obfuscator": "^4.0.0",
                 "source-map": "^0.7.3",
                 "typescript": "^4.0.3",
@@ -120,23 +118,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
             "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
             "dev": true
-        },
-        "node_modules/@types/source-list-map": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-            "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-            "dev": true
-        },
-        "node_modules/@types/webpack-sources": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.0.0.tgz",
-            "integrity": "sha512-a5kPx98CNFRKQ+wqawroFunvFqv7GHm/3KOI52NY9xWADgc8smu4R6prt4EU/M4QfVjvgBkMqU4fBhw3QfMVkg==",
-            "dev": true,
-            "dependencies": {
-                "@types/node": "*",
-                "@types/source-list-map": "*",
-                "source-map": "^0.7.3"
-            }
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -1762,7 +1743,8 @@
         "node_modules/source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
+            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+            "dev": true
         },
         "node_modules/source-map": {
             "version": "0.7.3",
@@ -2116,26 +2098,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/webpack-sources": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.0.1.tgz",
-            "integrity": "sha512-A9oYz7ANQBK5EN19rUXbvNgfdfZf5U2gP0769OXsj9CvYkCR6OHOsd6OKyEy4H38GGxpsQPKIL83NC64QY6Xmw==",
-            "dependencies": {
-                "source-list-map": "^2.0.1",
-                "source-map": "^0.6.1"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/webpack-sources/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/webpack/node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -2314,23 +2276,6 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
             "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
             "dev": true
-        },
-        "@types/source-list-map": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-            "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
-            "dev": true
-        },
-        "@types/webpack-sources": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.0.0.tgz",
-            "integrity": "sha512-a5kPx98CNFRKQ+wqawroFunvFqv7GHm/3KOI52NY9xWADgc8smu4R6prt4EU/M4QfVjvgBkMqU4fBhw3QfMVkg==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*",
-                "@types/source-list-map": "*",
-                "source-map": "^0.7.3"
-            }
         },
         "@webassemblyjs/ast": {
             "version": "1.11.0",
@@ -3643,7 +3588,8 @@
         "source-list-map": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
+            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
+            "dev": true
         },
         "source-map": {
             "version": "0.7.3",
@@ -3955,22 +3901,6 @@
             "requires": {
                 "clone-deep": "^4.0.1",
                 "wildcard": "^2.0.0"
-            }
-        },
-        "webpack-sources": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.0.1.tgz",
-            "integrity": "sha512-A9oYz7ANQBK5EN19rUXbvNgfdfZf5U2gP0769OXsj9CvYkCR6OHOsd6OKyEy4H38GGxpsQPKIL83NC64QY6Xmw==",
-            "requires": {
-                "source-list-map": "^2.0.1",
-                "source-map": "^0.6.1"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                }
             }
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "dependencies": {
         "loader-utils": "^2.0.0",
         "multi-stage-sourcemap": "^0.3.1",
-        "multimatch": "^5.0.0",
-        "webpack-sources": "^2.0.1"
+        "multimatch": "^5.0.0"
     },
     "peerDependencies": {
         "javascript-obfuscator": "^2.8.0 || ^3.0.0 || ^4.0.0",
@@ -26,7 +25,6 @@
     },
     "devDependencies": {
         "@types/node": "^14.11.8",
-        "@types/webpack-sources": "^2.0.0",
         "javascript-obfuscator": "^4.0.0",
         "source-map": "^0.7.3",
         "typescript": "^4.0.3",


### PR DESCRIPTION
Use of this package was removed in https://github.com/javascript-obfuscator/webpack-obfuscator/commit/390b5ae7fd7e07fe12afcf6f0e5be6515a0f2782 as `webpack` exports `sources`, so this dep isn't used anymore.

Recent versions of `webpack` have moved on to `webpack-sources` v3, so this dep is just hanging around.