### PR TITLE
Fix sourcemap sourcesContent not aligned to sources

### DIFF
--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -79,10 +79,6 @@ export class WebpackObfuscatorPlugin {
                                         toSourceMap: compilation.assets[fileName].source()
                                     });
                                     const finalSourcemap = JSON.parse(transferredSourceMap);
-
-                                    finalSourcemap['sourcesContent'] = JSON.parse(
-                                        assets[fileName].source().toString()
-                                    )['sourcesContent'];
                                     assets[fileName] = new sources.RawSource(JSON.stringify(finalSourcemap), false);
                                 }
 
@@ -109,7 +105,6 @@ export class WebpackObfuscatorPlugin {
                                     toSourceMap: inputSourceMap
                                 });
                                 const finalSourcemap = JSON.parse(transferredSourceMap);
-                                finalSourcemap['sourcesContent'] = inputSourceMap['sourcesContent'];
 
                                 // @ts-ignore Wrong types
                                 assets[fileName] = new sources.SourceMapSource(


### PR DESCRIPTION
The `sources` array of merged source maps is not always in the same order as the original `sources` array. By using the original source map's `sourcesContent` together with the merged source map's `sources`, the 2 array might not be aligned, which produces a malformed source map.

I believe `sourcesContent` was copied from input to the merged source map because the `multi-stage-sourcemap` library at one point did not produce `sourcesContent`. But `multi-stage-sourcemap` has added support for `sourcesContent` since version `0.3.0` (this project requires `^0.3.1`).